### PR TITLE
root->alias, backlog-> 128, fix autoindex filename

### DIFF
--- a/config/Config.cpp
+++ b/config/Config.cpp
@@ -135,11 +135,11 @@ void Config::parseServer(void) {
             hasServerName = true;
         } else if (title == "error_page") {
             newServer.parseErrorPages(tokens);
-        } else if (title == "root") {
+        } else if (title == "alias") {
             if (hasRoot) {
                 throw std::out_of_range("duplicate root entry in server");
             }
-            newServer.parseRoot(tokens);
+            newServer.parseAlias(tokens);
             hasRoot = true;
         } else if (title == "index") {
             newServer.parseIndex(tokens);
@@ -158,7 +158,7 @@ void Config::parseServer(void) {
         newServer.addIndex("index.html");
     if (newServer.getListenPort() == 0)
         throw std::out_of_range("parseServer: missing listen port");
-    if (newServer.getRoot().empty())
+    if (newServer.getAlias().empty())
         throw std::out_of_range("missing root directory of server");
     if (newServer.getLocations().empty())
         throw std::out_of_range("missing location entry in server");

--- a/config/LocationConfig.cpp
+++ b/config/LocationConfig.cpp
@@ -8,7 +8,7 @@
 
 LocationConfig::LocationConfig()
 	: URL()
-	, root()
+	, alias()
 	, index()
 	, limitExcept()
 	, returnCode()
@@ -20,7 +20,7 @@ LocationConfig::LocationConfig()
 
 LocationConfig::LocationConfig(const ServerConfig& server)
 	: URL()
-	, root(server.getRoot())
+	, alias(server.getAlias())
 	, index(server.getIndex())
 	, limitExcept()
 	, returnCode(server.getReturnCode())
@@ -32,7 +32,7 @@ LocationConfig::LocationConfig(const ServerConfig& server)
 
 LocationConfig::LocationConfig(const LocationConfig& src)
 	: URL(src.URL)
-	, root(src.root)
+	, alias(src.alias)
 	, index(src.index)
 	, limitExcept(src.limitExcept)
 	, returnCode(src.returnCode)
@@ -46,7 +46,7 @@ LocationConfig::~LocationConfig() {}
 
 LocationConfig& LocationConfig::operator=(const LocationConfig &src) {
 	URL = src.URL;
-	root = src.root;
+	alias = src.alias;
 	index = src.index;
 	limitExcept = src.limitExcept;
 	returnCode = src.returnCode;
@@ -94,17 +94,17 @@ void LocationConfig::parseURL(std::queue<std::string> &tokens) {
     }
 }
 
-void LocationConfig::parseRoot(std::queue<std::string> &tokens) {
+void LocationConfig::parseAlias(std::queue<std::string> &tokens) {
 	if (tokens.empty()) {
-        throw std::out_of_range("parseRoot: root expects exactly 2 arguments");
+        throw std::out_of_range("parseAlias: root expects exactly 2 arguments");
     }
     std::string path = tokens.front();
     if (tokens.front().back() != ';') {
         throw std::out_of_range("missing ';' after root path");
     }
-    root = tokens.front();
+    alias = tokens.front();
 	tokens.pop();
-	root.pop_back();
+	alias.pop_back();
 }
 
 void LocationConfig::parseIndex(std::queue<std::string> &tokens) {
@@ -258,8 +258,8 @@ const std::string& LocationConfig::getURL(void) const {
 	return URL;
 }
 
-const std::string& LocationConfig::getRoot(void) const {
-	return root;
+const std::string& LocationConfig::getAlias(void) const {
+	return alias;
 }
 
 const std::vector<std::string>& LocationConfig::getIndex(void) const {

--- a/config/LocationConfig.hpp
+++ b/config/LocationConfig.hpp
@@ -10,7 +10,7 @@ class ServerConfig;
 class LocationConfig {
 private:
     std::string             	URL;
-    std::string             	root;
+    std::string             	alias;
     std::vector<std::string>	index;
 	std::vector<std::string>	limitExcept;
     int                     	returnCode;
@@ -31,7 +31,7 @@ private:
 	bool	isNumber(const std::string& str) const;
 public:
 	void	parseURL(std::queue<std::string>& tokens);
-	void	parseRoot(std::queue<std::string>& tokens);
+	void	parseAlias(std::queue<std::string>& tokens);
 	void	parseIndex(std::queue<std::string>& tokens);
 	void	parseLimitExcept(std::queue<std::string>& tokens);
 	void	parseAutoIndex(std::queue<std::string>& tokens);
@@ -41,7 +41,7 @@ public:
 	void	parseClientMaxBodySize(std::queue<std::string>& tokens);
 public:
 	const std::string&				getURL(void) const;
-	const std::string&				getRoot(void) const;
+	const std::string&				getAlias(void) const;
 	const std::vector<std::string>&	getIndex(void) const;
 	const std::vector<std::string>&	getLimitExcept(void) const;
 	int								getReturnCode(void) const;

--- a/config/ServerConfig.cpp
+++ b/config/ServerConfig.cpp
@@ -7,7 +7,7 @@
 ServerConfig::ServerConfig()
 	: serverName()
 	, listenPort()
-	, root("index.html")
+	, alias("index.html")
 	, locations()
 	, errorPages()
 	, index()
@@ -18,7 +18,7 @@ ServerConfig::ServerConfig()
 ServerConfig::ServerConfig(const ServerConfig& src)
 	: serverName(src.serverName)
 	, listenPort(src.listenPort)
-	, root(src.root)
+	, alias(src.alias)
 	, locations(src.locations)
 	, errorPages(src.errorPages)
 	, index(src.index)
@@ -31,7 +31,7 @@ ServerConfig::~ServerConfig() {}
 ServerConfig& ServerConfig::operator=(const ServerConfig &src) {
 	serverName = src.serverName;
 	listenPort = src.listenPort;
-	root = src.root;
+	alias = src.alias;
 	locations = src.locations;
 	errorPages = src.errorPages;
 	index = src.index;
@@ -95,14 +95,14 @@ void ServerConfig::parseListenPort(std::queue<std::string> &tokens) {
 		throw std::out_of_range("parseListenPort: port number out of range");
 }
 
-void ServerConfig::parseRoot(std::queue<std::string> &tokens) {
+void ServerConfig::parseAlias(std::queue<std::string> &tokens) {
 	if (tokens.empty())
-        throw std::out_of_range("parseRoot: no value");
-	root = tokens.front();
+        throw std::out_of_range("parseAlias: no value");
+	alias = tokens.front();
 	tokens.pop();
-	if (root.back() != ';')
-		throw std::out_of_range("parseRoot: missing ';' after root path");
-	root.pop_back();
+	if (alias.back() != ';')
+		throw std::out_of_range("parseAlias: missing ';' after root path");
+	alias.pop_back();
 }
 
 void ServerConfig::parseIndex(std::queue<std::string>& tokens) {
@@ -127,8 +127,8 @@ void ServerConfig::parseLocation(std::queue<std::string> &tokens) {
     while (!tokens.empty() && tokens.front() != "}") {
         std::string key = tokens.front();
         tokens.pop();
-        if (key == "root") {
-            newLocation.parseRoot(tokens);
+        if (key == "alias") {
+            newLocation.parseAlias(tokens);
         } else if (key == "index") {
             newLocation.parseIndex(tokens);
         } else if (key == "limit_except") {
@@ -226,8 +226,8 @@ int ServerConfig::getListenPort(void) const {
 	return listenPort;
 }
 
-const std::string& ServerConfig::getRoot(void) const {
-	return root;
+const std::string& ServerConfig::getAlias(void) const {
+	return alias;
 }
 
 const std::vector<LocationConfig>& ServerConfig::getLocations(void) const {

--- a/config/ServerConfig.hpp
+++ b/config/ServerConfig.hpp
@@ -10,7 +10,7 @@ class ServerConfig {
 private:
 	std::string                	serverName;
 	int                        	listenPort;
-    std::string                	root;
+    std::string                	alias;
 	std::vector<LocationConfig>	locations;
 	std::map<int, std::string> 	errorPages;
     std::vector<std::string>   	index;
@@ -28,7 +28,7 @@ private:
 public:
 	void	parseServerName(std::queue<std::string>& tokens);
 	void	parseListenPort(std::queue<std::string>& tokens);
-	void	parseRoot(std::queue<std::string>& tokens);
+	void	parseAlias(std::queue<std::string>& tokens);
 	void	parseIndex(std::queue<std::string>& tokens);
 	void	parseLocation(std::queue<std::string>& tokens);
 	void	parseErrorPages(std::queue<std::string>& tokens);
@@ -36,7 +36,7 @@ public:
 public:
 	const std::string&					getServerName(void) const;
 	int									getListenPort(void) const;
-	const std::string&					getRoot(void) const;
+	const std::string&					getAlias(void) const;
 	const std::vector<LocationConfig>&	getLocations(void) const;
 	const std::map<int, std::string>&	getErrorPages(void) const;
 	const std::vector<std::string>&		getIndex(void) const;

--- a/http/Router_autoindex.cpp
+++ b/http/Router_autoindex.cpp
@@ -66,7 +66,7 @@ std::string Router::generateDirectoryListing(const std::string& directoryPath) {
     closedir(dir);
     html += "</pre><hr></body></html>";
 
-	const std::string&  autoFile = '.' + directoryPath + "/" + "autoindex.html";
+    std::string  autoFile = '.' + directoryPath + "/" + "autoindex.html";
     std::ofstream       outputFile(autoFile);
     if (outputFile.is_open()) {
         outputFile << html;
@@ -75,5 +75,6 @@ std::string Router::generateDirectoryListing(const std::string& directoryPath) {
     } else {
         throw Router::ErrorException(500, "generateDirectoryListing: " + std::string(strerror(errno)));
     }
+    autoFile.erase(0, 1);
     return autoFile;
 }

--- a/http/Router_utils.cpp
+++ b/http/Router_utils.cpp
@@ -137,7 +137,7 @@ void Router::validateContentType() {
 
 void Router::handleDirectory() {
     const std::vector<std::string>& indexFiles = matchLocation ? matchLocation->getIndex() : config->getIndex();
-    const std::string& directoryPath = matchLocation ? matchLocation->getRoot() : config->getRoot();
+    const std::string& directoryPath = matchLocation ? matchLocation->getAlias() : config->getAlias();
     std::string testURL;
 
     if (configURL.back() != '/')
@@ -166,14 +166,14 @@ void Router::replaceURL(const std::string& UrlFromRequest) {
             configURL = UrlFromRequest;
             if (matchLocation->getURL() == "/")
                 configURL = "/" + UrlFromRequest;
-            if (matchLocation->getRoot().empty())
-                configURL.replace(0, matchLocation->getURL().size(), config->getRoot());
+            if (matchLocation->getAlias().empty())
+                configURL.replace(0, matchLocation->getURL().size(), config->getAlias());
             else 
-                configURL.replace(0, matchLocation->getURL().size(), matchLocation->getRoot());
+                configURL.replace(0, matchLocation->getURL().size(), matchLocation->getAlias());
         }
     }
     else {
-        configURL = config->getRoot() + UrlFromRequest;
+        configURL = config->getAlias() + UrlFromRequest;
     }
 }
 

--- a/server.conf
+++ b/server.conf
@@ -5,23 +5,28 @@ http {
 
         error_page 404 error.html; # Default error pages
 
-        root /document;
+        alias /document;
         index index.py;
 
         location / {
             limit_except GET POST DELETE;
-            root /document/cgi;
-            index index.py;
+            alias /document/cgi;
+            # index index.py;
+            autoindex on;
         }
 
         location /cgi {
-            root /document;
-            index index.py post.php delete.pl;
+            alias /document;
+            # index index.py post.php delete.pl;
             autoindex on; # Directory listing
         }
         # Redirect to a different URL
         location /redirect {
             return 301 http://www.google.com;
+        }
+
+        location /auto_test {
+            autoindex on;
         }
     }
 
@@ -29,7 +34,7 @@ http {
     server {
         listen 4242; # Port 4242
         server_name testServer; # Hostname Local host와 비교!
-        root /document/YoupiBanane;
+        alias /document/YoupiBanane;
         index youpi.bad_extension;
         client_max_body_size 100000000;
 
@@ -44,19 +49,19 @@ http {
         }
 
         location /put_test {
-            root /document/YoupiBanane/put_test;
+            alias /document/YoupiBanane/put_test;
             index put_test.test;
         }
 
         location /post_body {
-            root /document/YoupiBanane/post_body;
+            alias /document/YoupiBanane/post_body;
             index post_body.test;
             client_max_body_size 100;
             #/post_body must answer anything to POST request with a maxBody of 100
         }
 
         location /directory {
-            root /document/YoupiBanane;
+            alias /document/YoupiBanane;
             index youpi.bad_extension;
         }
         # Other settings similar to Server block 1

--- a/server/Server_listen.cpp
+++ b/server/Server_listen.cpp
@@ -18,7 +18,7 @@
 #include <cstdio>
 #include <utility>
 
-static int backlog = 1000;
+static int backlog = 128;
 static const std::string    default_host = "127.0.0.1";
 
 int Server::createSocket() {


### PR DESCRIPTION
1. 기존 alias방식으로 구현되어 있었으나 root라는 키워드로 잘못 쓰던 부분 모두 alias 로 이름 수정 
2. backlog 최댓값을 128로 수정
3. autoindex 파일 생성 시 현재 디렉토리를 의미하는 '.' 을 추가하는데, handleGet 에서 한번 더 추가하기 때문에 생기는 에러 발견 -> 파일 생성 후 . 삭제하는 방식으로 수정